### PR TITLE
Adding check for the MIM PowerShell Module version

### DIFF
--- a/Solutions/UserProfile.MIMSync/SharePointSync.psm1
+++ b/Solutions/UserProfile.MIMSync/SharePointSync.psm1
@@ -75,6 +75,18 @@ function Install-SharePointSyncConfiguration
     {
         throw "The current user must be a member of the Synchronization Service Admins group before this command can be run.  You may need to logoff/logon before the group membership takes effect."
     }
+
+    $MimPowerShellModuleAssembly = Get-Item -Path (Join-Path (Get-SynchronizationServicePath) UIShell\Microsoft.DirectoryServices.MetadirectoryServices.Config.dll)
+    if ($MimPowerShellModuleAssembly.VersionInfo.ProductMajorPart -eq 4 -and
+        $MimPowerShellModuleAssembly.VersionInfo.ProductMinorPart -eq 3 -and 
+        $MimPowerShellModuleAssembly.VersionInfo.ProductBuildPart -ge 2064)
+    {
+        Write-Verbose "Sufficient MIM PowerShell version detected (>= 4.3.2064): $($MimPowerShellModuleAssembly.VersionInfo.ProductVersion)"
+    }
+    else
+    {
+        throw "SharePoint Sync requires MIM PowerShell version 4.3.2064 or greater (this version is currently installed: $($MimPowerShellModuleAssembly.VersionInfo.ProductVersion). Please install the latest MIM hotfix."
+    }
     #endregion
 
     ### Load the Synchronization PowerShell snap-in


### PR DESCRIPTION
SharePoint Sync requires a minimum version of the MIM PowerShell module
for fixes to the Set-MIISECMA2Configuration cmdlet.  The older version
of that command has different parameters so will cause our function to
fail.